### PR TITLE
Rework policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ repositories:
   * `project`: Project ID to target
   * `group`: Group/Namespace ID to target
   * `recurse`: Specifies groups should be recursed when specifying `group`
-  * `images`: Image paths of repository/image
+  * `images`: __array__ 
+    * Image paths of repository/image
   * `policies` __array__
     * Name of policies
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Application config is specified with a yaml configuration file, with an example 
 ```yaml
 access_token: myaccesstoken
 url: https://gitlab.privateinstance.com
+debug: true
 policies:
 - name: nonsemverpolicy
   filter:
@@ -54,13 +55,15 @@ policies:
     age: 30
 repositories:
 - project: 123
-  image: myproject/somerepository
+  images: 
+  - myproject/somerepository
   policies:
   - nonsemverpolicy
 ```
 
 * `access_token`: Private access token with `api` read/write scope
 * `url`: Gitlab instance URL
+* `debug`: Trace-level logging should be enabled
 * `policies`: __array__
   * `name`: Name of policy
   * `filter`: __object__
@@ -70,11 +73,15 @@ repositories:
     * `age`: (Optional) Specifies amount of days to keep tags
 * `repositories` __array__
   * `project`: Project ID to target
-  * `image`: Path of repository/image
+  * `group`: Group/Namespace ID to target
+  * `recurse`: Specifies groups should be recursed when specifying `group`
+  * `images`: Image paths of repository/image
   * `policies` __array__
     * Name of policies
 
 Environment variable can also be used, which are the uppercase equivelent of the yaml config directives, e.g. `ACCESS_TOKEN`
+
+Targets are specified by supplying optional `project`, `group` and `images`, which are used for filtering
 
 ## Docker
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,6 @@ func initConfig() {
 
 func initLogging() {
 	if viper.GetBool("debug") {
-		log.SetLevel(log.DebugLevel)
+		log.SetLevel(log.TraceLevel)
 	}
 }

--- a/config.example.yml
+++ b/config.example.yml
@@ -2,6 +2,7 @@
 
 access_token: myaccesstoken
 url: https://gitlab.privateinstance.com
+debug: true
 policies:
 - name: nonsemverpolicy
   filter:
@@ -10,9 +11,26 @@ policies:
     keep: 5
     age: 30
 repositories:
+# Applies to project 123
 - project: 123
-  # group: 456
   images: 
   - myproject/somerepository
   policies:
   - nonsemverpolicy
+# Applies to immediate projects in group 456
+- group: 456
+  images: 
+  - myproject/somerepository
+  policies:
+  - nonsemverpolicy
+# Applies recursively to all projects in group 456 and subgroups
+- group: 456
+  recurse: true
+  images: 
+  - myproject/somerepository
+  policies:
+  - nonsemverpolicy
+# Applies to all projects
+- policies:
+  - nonsemverpolicy
+

--- a/config.example.yml
+++ b/config.example.yml
@@ -11,6 +11,8 @@ policies:
     age: 30
 repositories:
 - project: 123
-  image: myproject/somerepository
+  # group: 456
+  images: 
+  - myproject/somerepository
   policies:
   - nonsemverpolicy

--- a/config.example.yml
+++ b/config.example.yml
@@ -10,24 +10,27 @@ policies:
     exclude: ^v.+
     keep: 5
     age: 30
+- name: uatpolicy
+  filter:
+    include: ^UAT_.+
+    keep: 5
+    age: 7
 repositories:
 # Applies to project 123
 - project: 123
   images: 
-  - myproject/somerepository
+  - myproject/app
+  - myproject/db
   policies:
   - nonsemverpolicy
 # Applies to immediate projects in group 456
 - group: 456
-  images: 
-  - myproject/somerepository
   policies:
   - nonsemverpolicy
-# Applies recursively to all projects in group 456 and subgroups
-- group: 456
+  - uatpolicy
+# Applies recursively to all projects in group 789 and subgroups
+- group: 789
   recurse: true
-  images: 
-  - myproject/somerepository
   policies:
   - nonsemverpolicy
 # Applies to all projects

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,7 +31,9 @@ type PolicyConfig struct {
 
 type RepositoryConfig struct {
 	Project  int      `yaml:"project"`
-	Image    string   `yaml:"image"`
+	Group    int      `yaml:"group"`
+	Recurse  bool     `yaml:"recurse"`
+	Images   []string `yaml:"images"`
 	Policies []string `yaml:"policies"`
 }
 


### PR DESCRIPTION
Adds support for evaluating all projects, with optional match on project id, group (optionally recursive) and image path